### PR TITLE
Allow to specify file extensions to be handled by the gatsby-plugin-n…

### DIFF
--- a/legacy/gatsby-plugin-netlify-cms-paths/README.md
+++ b/legacy/gatsby-plugin-netlify-cms-paths/README.md
@@ -50,7 +50,9 @@ module.exports = {
       resolve: `gatsby-plugin-netlify-cms-paths`,
       options: {
         // Path to your Netlify CMS config file
-        cmsConfig: `/static/admin/config.yml`
+        cmsConfig: `/static/admin/config.yml`,
+        // File types to process
+        extensions: [`.png`, `.jpeg`]
       }
     }
   ]

--- a/legacy/gatsby-plugin-netlify-cms-paths/src/index.js
+++ b/legacy/gatsby-plugin-netlify-cms-paths/src/index.js
@@ -1,15 +1,19 @@
+const path = require(`path`)
 const select = require(`unist-util-select`)
 const makeRelative = require(`./make-relative`)
 
 module.exports = async ({ markdownNode, markdownAST, getNode }, options) => {
 	const imgs = select(markdownAST, `image`)
+	const extensions = options && options.extensions && new Set(options.extensions)
 	if(imgs.length){
 		const { absolutePath } = getNode(markdownNode.parent)
 		const newPaths = await Promise.all(imgs.map(({ url }) => {
 			return makeRelative(absolutePath, url, options)
 		}))
 		imgs.forEach((img, key) => {
-			img.url = newPaths[key]
+			if (!extensions || extensions.has(path.extname(img.url))) {
+				img.url = newPaths[key]
+			}
 		})
 	}
 }


### PR DESCRIPTION
…etlify-cms-paths plugin.

Maybe there are other use cases, but my personal use case is that some files are not handled by gatsby-plugin-sharp (like gifs). So there is no need to make their paths relative.